### PR TITLE
MULTIPLAYER: Replace aioredis with redis, update README, ensure redis starts before server

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,7 @@
 
 This project contains code for hosting online multiplayer lobbies for compatable Humongous Entertainment games.
 
-## Getting Started
-### Installing
-Both the session and web servers requires Redis to be installed.  This is needed for both servers to share session data to each other.
-
+# Local Development
 Clone this repo and checkout to the multiplayer branch:
 ```
 git clone https://github.com/scummvm/scummvm-sites.git
@@ -13,47 +10,7 @@ git clone https://github.com/scummvm/scummvm-sites.git
 git checkout multiplayer
 ```
 
-To start the session server, create a new virtual envrionment and install the requirements.
-```
-python3 -m venv .env
-source .env/bin/activate
-
-python3 -m pip install -r requirements.txt
-```
-
-Backyard Football and Backyard Baseball 2001 needs a lobby server to play online.  You will need
-[Node.js](https://nodejs.org/en/) installed to run it.
-
-If you're planning to run the web server, install the requirements located in the web directory.
-```
-python3 -m pip install -r web/requirements.txt
-```
-
-### Running
-To run the session server, simply run the main.py script
-```
-python3 main.py
-```
-It should listen for connections on port 9120.  Remember to configure ScummVM to connect to localhost or whatever address your server is running in.
-
-To start the lobby server, go to the `lobby` directory and install the dependencies:
-```
-cd lobby
-npm install
-```
-
-After that's done, you can simply run the `run.js` file.
-```
-node run.js
-```
-
-Running a web server is unnecessary if you just want your server to host sessions, but if you want to, you can start one up by using uvicorn.
-```
-cd web
-uvicorn main:app --reload
-```
-
-## Docker
+## With Docker
 The session, lobby and web server can be run within Docker via docker-compose.
 ```
 docker-compose build
@@ -61,3 +18,50 @@ docker-compose up
 ```
 
 This will build Docker images for all three servers and starts a container for them simultaneously alongside with Redis.
+
+## Without Docker
+### Redis
+Both the session and web servers use Redis.  It is needed for both servers to share session data to each other.  To install Redis, you can follow [the instructions on their website](https://redis.io/docs/getting-started/installation/). Then, start up a Redis instance by running
+```
+redis-server
+```
+### Session server
+To start the session server, first create a new virtual envrionment and install its requirements.
+```
+python3 -m venv .env
+source .env/bin/activate
+
+python3 -m pip install -r requirements.txt
+```
+Then, run it with the main.py script:
+```
+python3 main.py
+```
+It should listen for connections on port 9120.  Remember to configure ScummVM to connect to localhost or whatever address your server is running in.
+
+### Lobby server
+Backyard Football and Backyard Baseball 2001 need a lobby server to play online.  You will need
+[Node.js](https://nodejs.org/en/) installed to run it.
+
+To start the lobby server, go to the `lobby` directory and install the dependencies:
+```
+cd lobby
+npm install
+```
+After that's done, you can simply run the `run.js` file.
+```
+node run.js
+```
+
+### Web server
+Running the web server isn't necessary if you just want your server to host sessions, but if you want to you can run it. First, go to the `web` directory and install the requirements there.
+```
+cd web
+python3 -m venv .env
+source .env/bin/activate
+python3 -m pip install -r requirements.txt
+```
+And then start the server with uvicorn
+```
+uvicorn main:app --reload
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
       - REDIS_HOST=redis
     ports:
       - "9120:9120/udp"
+    depends_on:
+      - redis
   lobby:
     build: ./lobby/
     environment:

--- a/web/main.py
+++ b/web/main.py
@@ -6,7 +6,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.requests import Request
 from fastapi.routing import Mount
 
-import aioredis
+from redis import asyncio as aioredis
 
 from config import *
 

--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -1,4 +1,4 @@
 fastapi==0.89.1
-aioredis==2.0.1
+redis==4.5.3
 uvicorn==0.20.0
 Jinja2==3.1.2


### PR DESCRIPTION
`aioredis` isn't supported anymore ([see here](https://github.com/aio-libs/aioredis-py#-aioredis-is-now-in-redis-py-420rc1-) and [here](https://discord.com/channels/837051141698486282/891840946013093942/1088536313860460584) for more info), so here we replace it with `redis`.

Also, updated README with full instructions for running the components locally with and without docker.

And, found that sometimes when running with docker compose, `server` would try to start before `redis` which caused the server to error out. Added `depends_on: redis` to ensure this does not happen.